### PR TITLE
NVDB-3899: Encoding error in ISO-8859-10

### DIFF
--- a/impl/src/main/java/no/vegvesen/nvdb/sosi/encoding/charset/DECN7.java
+++ b/impl/src/main/java/no/vegvesen/nvdb/sosi/encoding/charset/DECN7.java
@@ -35,6 +35,7 @@ import java.nio.charset.CharsetEncoder;
  * The DEC Norwegian 7-bits character set.
  *
  * @author Tore Eide Andersen (Kantega AS)
+ * @author Oystein Steimler (Itema AS)
  */
 public class DECN7 extends SosiCharset {
 
@@ -83,7 +84,7 @@ public class DECN7 extends SosiCharset {
 
     private static class Encoder extends SosiCharsetEncoder {
         private Encoder(Charset cs) {
-            super(cs);
+            super(cs, null);
         }
 
         @Override

--- a/impl/src/main/java/no/vegvesen/nvdb/sosi/encoding/charset/DOSN8.java
+++ b/impl/src/main/java/no/vegvesen/nvdb/sosi/encoding/charset/DOSN8.java
@@ -35,6 +35,7 @@ import java.nio.charset.CharsetEncoder;
  * The MS-DOS Norwegian 8-bits character set.
  *
  * @author Tore Eide Andersen (Kantega AS)
+ * @author Oystein Steimler (Itema AS)
  */
 public class DOSN8 extends SosiCharset {
 
@@ -83,7 +84,7 @@ public class DOSN8 extends SosiCharset {
 
     private static class Encoder extends SosiCharsetEncoder {
         private Encoder(Charset cs) {
-            super(cs);
+            super(cs, null);
         }
 
         @Override

--- a/impl/src/main/java/no/vegvesen/nvdb/sosi/encoding/charset/ISO8859_10.java
+++ b/impl/src/main/java/no/vegvesen/nvdb/sosi/encoding/charset/ISO8859_10.java
@@ -30,49 +30,55 @@ import no.vegvesen.nvdb.sosi.utils.BiMap;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * The ISO-8859-10 8-bits character set (includes Sami characters).
  *
  * @author Tore Eide Andersen (Kantega AS)
+ * @author Oystein Steimler (Itema AS)
  */
 public class ISO8859_10 extends SosiCharset {
+
+    private final static String[] aliases = {"ISO8859-10", "8859-10", "latin6"};
+
+    private final static List<Character> chars = Arrays.asList(
+        /* 0xa0 */
+            '\u00a0', '\u0104', '\u0112', '\u0122', '\u012a', '\u0128', '\u0136', '\u00a7',
+            '\u013b', '\u0110', '\u0160', '\u0166', '\u017d', '\u00ad', '\u016a', '\u014a',
+        /* 0xb0 */
+            '\u00b0', '\u0105', '\u0113', '\u0123', '\u012b', '\u0129', '\u0137', '\u00b7',
+            '\u013c', '\u0111', '\u0161', '\u0167', '\u017e', '\u2015', '\u016b', '\u014b',
+        /* 0xc0 */
+            '\u0100', '\u00c1', '\u00c2', '\u00c3', '\u00c4', '\u00c5', '\u00c6', '\u012e',
+            '\u010c', '\u00c9', '\u0118', '\u00cb', '\u0116', '\u00cd', '\u00ce', '\u00cf',
+        /* 0xd0 */
+            '\u00d0', '\u0145', '\u014c', '\u00d3', '\u00d4', '\u00d5', '\u00d6', '\u0168',
+            '\u00d8', '\u0172', '\u00da', '\u00db', '\u00dc', '\u00dd', '\u00de', '\u00df',
+        /* 0xe0 */
+            '\u0101', '\u00e1', '\u00e2', '\u00e3', '\u00e4', '\u00e5', '\u00e6', '\u012f',
+            '\u010d', '\u00e9', '\u0119', '\u00eb', '\u0117', '\u00ed', '\u00ee', '\u00ef',
+        /* 0xf0 */
+            '\u00f0', '\u0146', '\u014d', '\u00f3', '\u00f4', '\u00f5', '\u00f6', '\u0169',
+            '\u00f8', '\u0173', '\u00fa', '\u00fb', '\u00fc', '\u00fd', '\u00fe', '\u0138');
 
     private final static BiMap<Byte, Character> charMap;
 
     static {
-        charMap = createCharMap(0xa0,
-
-        /* 0xa0 */
-                0x00a0, 0x0104, 0x0112, 0x0122, 0x012a, 0x0128, 0x0136, 0x00a7,
-                0x013b, 0x0110, 0x0160, 0x0166, 0x017d, 0x00ad, 0x016a, 0x014a,
-        /* 0xb0 */
-                0x00b0, 0x0105, 0x0113, 0x0123, 0x012b, 0x0129, 0x0137, 0x00b7,
-                0x013c, 0x0111, 0x0161, 0x0167, 0x017e, 0x2015, 0x016b, 0x014b,
-        /* 0xc0 */
-                0x0100, 0x00c1, 0x00c2, 0x00c3, 0x00c4, 0x00c5, 0x00c6, 0x012e,
-                0x010c, 0x00c9, 0x0118, 0x00cb, 0x0116, 0x00cd, 0x00ce, 0x00cf,
-        /* 0xd0 */
-                0x00d0, 0x0145, 0x014c, 0x00d3, 0x00d4, 0x00d5, 0x00d6, 0x0168,
-                0x00d8, 0x0172, 0x00da, 0x00db, 0x00dc, 0x00dd, 0x00de, 0x00df,
-        /* 0xe0 */
-                0x0101, 0x00e1, 0x00e2, 0x00e3, 0x00e4, 0x00e5, 0x00e6, 0x012f,
-                0x010d, 0x00e9, 0x0119, 0x00eb, 0x0117, 0x00ed, 0x00ee, 0x00ef,
-        /* 0xf0 */
-                0x00f0, 0x0146, 0x014d, 0x00f3, 0x00f4, 0x00f5, 0x00f6, 0x0169,
-                0x00f8, 0x0173, 0x00fa, 0x00fb, 0x00fc, 0x00fd, 0x00fe, 0x0138);
+        charMap = createCharMap(0xa0, chars );
     }
 
-    private static BiMap<Byte, Character> createCharMap(int offset, int... characters) {
+    private static BiMap<Byte, Character> createCharMap(int offset, List<Character> characters) {
         BiMap<Byte, Character> charMap = new BiMap<>();
-        for (int index = 0; index < characters.length; index++) {
-            charMap.put((byte)(index + offset), (char)characters[index]);
+        for (int index = 0; index < characters.size(); index++) {
+            charMap.put((byte)(index + offset), characters.get(index));
         }
         return charMap;
     }
 
     public ISO8859_10() {
-        super("ISO-8859-10");
+        super("ISO-8859-10", aliases);
     }
 
     @Override
@@ -104,7 +110,7 @@ public class ISO8859_10 extends SosiCharset {
 
     private static class Encoder extends SosiCharsetEncoder {
         private Encoder(Charset cs) {
-            super(cs);
+            super(cs, chars);
         }
 
         @Override

--- a/impl/src/main/java/no/vegvesen/nvdb/sosi/encoding/charset/ND7.java
+++ b/impl/src/main/java/no/vegvesen/nvdb/sosi/encoding/charset/ND7.java
@@ -35,6 +35,7 @@ import java.nio.charset.CharsetEncoder;
  * The Norsk Data 7-bits character set.
  *
  * @author Tore Eide Andersen (Kantega AS)
+ * @author Oystein Steimler (Itema AS)
  */
 public class ND7 extends SosiCharset {
 
@@ -83,7 +84,7 @@ public class ND7 extends SosiCharset {
 
     private static class Encoder extends SosiCharsetEncoder {
         private Encoder(Charset cs) {
-            super(cs);
+            super(cs, null);
         }
 
         @Override

--- a/impl/src/main/java/no/vegvesen/nvdb/sosi/encoding/charset/SosiCharset.java
+++ b/impl/src/main/java/no/vegvesen/nvdb/sosi/encoding/charset/SosiCharset.java
@@ -35,11 +35,16 @@ import static java.util.Objects.isNull;
  * Base class for all SOSI charsets
  *
  * @author Tore Eide Andersen (Kantega AS)
+ * @author Oystein Steimler (Itema AS)
  */
 public abstract class SosiCharset extends Charset {
 
     public SosiCharset(String canonicalName) {
         super(canonicalName, null);
+    }
+
+    public SosiCharset(String canonicalName, String[] aliases) {
+        super(canonicalName, aliases);
     }
 
     /**

--- a/impl/src/main/java/no/vegvesen/nvdb/sosi/encoding/charset/SosiCharsetEncoder.java
+++ b/impl/src/main/java/no/vegvesen/nvdb/sosi/encoding/charset/SosiCharsetEncoder.java
@@ -30,6 +30,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
+import java.util.List;
 
 /**
  * Generic charset encoder for SOSI output stream writers.
@@ -37,15 +38,24 @@ import java.nio.charset.CoderResult;
  * Based on the Java ISO-8859-1 charset encoder class.
  *
  * @author Tore Eide Andersen (Kantega AS)
+ * @author Oystein Steimler (Itema AS)
  */
 abstract class SosiCharsetEncoder extends CharsetEncoder {
-    SosiCharsetEncoder(Charset cs) {
+
+    private List<Character> chars;
+
+    SosiCharsetEncoder(Charset cs, List<Character> chars) {
         super(cs, 1.0f, 1.0f);
+        this.chars = chars;
     }
 
     @Override
     public boolean canEncode(char c) {
-        return c <= '\u00FF';
+        if ( chars == null ) {
+            return c <= '\u00FF';
+        } else {
+           return chars.contains(c) ;
+        }
     }
 
     @Override
@@ -106,7 +116,7 @@ abstract class SosiCharsetEncoder extends CharsetEncoder {
         try {
             while (src.hasRemaining()) {
                 char c = src.get();
-                if (c <= '\u00FF') {
+                if (canEncode(c)) {
                     if (!dst.hasRemaining())
                         return CoderResult.OVERFLOW;
                     dst.put(fromUtf16(c));

--- a/impl/src/test/java/no/vegvesen/nvdb/sosi/encoding/charset/ISO8859_10Test.java
+++ b/impl/src/test/java/no/vegvesen/nvdb/sosi/encoding/charset/ISO8859_10Test.java
@@ -1,0 +1,76 @@
+package no.vegvesen.nvdb.sosi.encoding.charset;
+
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+public class ISO8859_10Test {
+
+    @Test
+    public void getISO8859_10FromProvider() {
+        Charset cs = SosiCharset.forName("ISO-8859-10");
+
+        assertThat(cs, instanceOf(ISO8859_10.class));
+        assertThat(cs, instanceOf(SosiCharset.class));
+        assertThat(cs, instanceOf(Charset.class));
+    }
+
+    @Test
+    public void testEncodeNorwegianChars() {
+        String norwegianChars = "æøåÆØÅ";
+
+        Charset cs = new ISO8859_10();
+        ByteBuffer encoded = cs.encode(norwegianChars);
+
+        ByteBuffer expected = ByteBuffer.wrap(new byte[] {(byte)0xe6, (byte)0xf8, (byte)0xe5, (byte)0xc6, (byte)0xd8, (byte)0xc5 });
+
+        assertThat( encoded.array(), equalTo(expected.array()));
+    }
+
+    @Test
+    public void testEncodeSami8bitChars() {
+        String samiChars = "Áá";
+
+        Charset cs = new ISO8859_10();
+        ByteBuffer encoded = cs.encode(samiChars);
+
+        ByteBuffer expected = ByteBuffer.wrap(new byte[] {(byte)0xc1, (byte)0xe1});
+
+        assertThat( encoded.array(), equalTo(expected.array()));
+    }
+
+    @Test
+    public void testEncodeSami16bitChars() {
+        String samiChars = "š";
+
+        Charset cs = new ISO8859_10();
+        ByteBuffer encoded = cs.encode(samiChars);
+
+        ByteBuffer expected = ByteBuffer.wrap(new byte[] {(byte)0xba});
+
+        assertThat( encoded.array(), equalTo(expected.array()));
+    }
+
+    /**
+     * Test that characters outside the range (0x0200) and characters inside the range but not contained in the
+     * character set is encoded to the replacement codepoint (normally 63 or 0xef which is '?' in ISO-8859).
+     */
+    @Test
+    public void testCharSubstitution() {
+        String unsupportedChar = "\u0200À";
+
+        Charset cs = new ISO8859_10();
+        ByteBuffer encoded = cs.encode(unsupportedChar);
+
+        ByteBuffer expected = ByteBuffer.wrap(new byte[] {(byte)0x3f, (byte)0x3f});
+
+        assertThat( encoded.array(), equalTo(expected.array()));
+
+    }
+
+}


### PR DESCRIPTION
* Fixed a bug in encoding of characters with codepoint > 0x00ff in ISO8859_10.
* Added some tests.